### PR TITLE
Add dependency for pyyaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,5 @@
 requires = [
     "setuptools>=42",
     "wheel>=0.45.1",
-    "pyyaml>=6.0.2"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django_yaml_field
-version = 0.1.2
+version = 0.1.3
 author = Kalinin Mitko
 author_email = kalinin.mitko@gmail.com
 description = Same as Django JSONField but represent it as YAML (internally stores as JSON)
@@ -19,6 +19,8 @@ package_dir =
     = src
 packages = find:
 python_requires = >=3.6
+install_requires =
+    pyyaml
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Add project dependency for pyyaml, because the component cannot be initialized without this dependency

Closes: #2